### PR TITLE
Add Supabase-backed collection pages

### DIFF
--- a/app/brands/[id]/page.tsx
+++ b/app/brands/[id]/page.tsx
@@ -4,36 +4,36 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const { data: category } = await supabaseServer
-    .from('categories')
+  const { data: brand } = await supabaseServer
+    .from('brands')
     .select('name')
     .eq('slug', id)
     .single();
-  return { title: `${category?.name || 'Category'} | Dope Deals` };
+  return { title: `${brand?.name || 'Brand'} | Dope Deals` };
 }
 
 export default async function Page({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const supabase = supabaseServer;
-  const { data: category } = await supabase
-    .from('categories')
+  const { data: brand } = await supabase
+    .from('brands')
     .select('*')
     .eq('slug', id)
     .single();
-  if (!category) {
+  if (!brand) {
     return (
       <div className="p-6">
-        <p className="text-sm text-muted-foreground">Category not found.</p>
+        <p className="text-sm text-muted-foreground">Brand not found.</p>
       </div>
     );
   }
   const { data: products } = await supabase
     .from('products')
     .select('*')
-    .eq('category_id', category.id);
+    .eq('brand_id', brand.id);
   return (
     <div className="px-6 py-8 space-y-8">
-      <Hero title={category.name} subtitle={category.description} />
+      <Hero title={brand.name} subtitle={brand.description} />
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         {products?.map((p) => (
           <ProductCard key={p.id} product={p} />

--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -1,22 +1,40 @@
-export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
-  return { title: `Product ${id} | Dope Deals` };
-}
-
-import { getStorage } from '@/lib/server-storage';
 import ProductDetail from './ProductDetail';
 import { Hero } from '@/components/design/NikeIndustrial';
+import { supabaseServer } from '@/lib/supabase-server';
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const { data: product } = await supabaseServer
+    .from('products')
+    .select('name')
+    .eq('id', id)
+    .single();
+  return { title: `${product?.name || 'Product'} | Dope Deals` };
+}
 
 export default async function Page({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const storage = await getStorage();
-  const product = await storage.getProduct(id);
-
+  const { data: product } = await supabaseServer
+    .from('products')
+    .select('*')
+    .eq('id', id)
+    .single();
+  if (!product) {
+    return (
+      <div className="p-6">
+        <p className="text-sm text-muted-foreground">Product not found.</p>
+      </div>
+    );
+  }
+  const productData = {
+    ...product,
+    imageUrl: (product as any).image_url,
+    inStock: (product as any).in_stock,
+  };
   return (
     <div className="px-6 py-8 space-y-8">
-      <Hero title={product?.name || 'Product'} subtitle={product?.description} />
-      <ProductDetail product={product} />
+      <Hero title={productData.name} subtitle={productData.description} />
+      <ProductDetail product={productData} />
     </div>
   );
 }
-

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,14 +1,13 @@
 export const metadata = {
-  title: "Products | Dope Deals",
+  title: 'Products | Dope Deals',
 };
-import { getStorage } from '@/lib/server-storage';
 import Filters from './components/Filters';
 import ProductCard from './components/ProductCard';
 import { Hero } from '@/components/design/NikeIndustrial';
+import { supabaseServer } from '@/lib/supabase-server';
 
 export default async function Page() {
-  const storage = await getStorage();
-  const products = await storage.getProducts();
+  const { data: products } = await supabaseServer.from('products').select('*');
   return (
     <div className="px-6 py-8 space-y-8">
       <Hero title="Dope Deals" subtitle="Industrial minimalism. Bold energy. Premium glass and accessories." />
@@ -17,11 +16,10 @@ export default async function Page() {
         <Filters />
       </div>
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-        {products.map((p: any) => (
+        {products?.map((p: any) => (
           <ProductCard key={p.id} product={p} />
         ))}
       </div>
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- Render category collection pages by querying Supabase categories and products
- Add brand collection pages pulling products by brand from Supabase
- Switch products listing and product detail pages to Supabase data

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8c2157f34832a80ba9ad5fa0be7a1