### PR TITLE
Await storage initialization when loading product details

### DIFF
--- a/components/ProductDetailsPage.tsx
+++ b/components/ProductDetailsPage.tsx
@@ -69,7 +69,7 @@ export default function ProductDetailsPage({
         setLoading(true);
         setError(null);
         
-        const storage = getStorage();
+        const storage = await getStorage();
         const productData = await storage.getProduct(productId);
         
         if (!productData) {


### PR DESCRIPTION
## Summary
- await the storage factory before invoking getProduct in the product details page to ensure the client is initialized

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68db44d9d648832ab86d1c30756a579a